### PR TITLE
Fix off-by-one error

### DIFF
--- a/day01/p2a.js
+++ b/day01/p2a.js
@@ -21,7 +21,7 @@ fs.readFile(process.argv[2], 'utf8', function(err, data) {
         }
 
         if(floor < 0) {
-            console.log(i);
+            console.log(i+1);
             return;
         }
     }


### PR DESCRIPTION
The for index starts at 0 but the floor number starts at 1. This currently gives a different output than the other solutions.
